### PR TITLE
feat: impl deserialized caching API and usage

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,27 +1,72 @@
+pub mod deser_cache;
+pub use deser_cache::DeserCache;
 use {
     crate::{
-        storage::{Error, StorageRead, StorageWrite},
+        primitive::{appendlog, commitlog, prollylist, prollytree},
+        storage::Error,
         Addr,
     },
-    tokio::io::AsyncRead,
+    std::{convert::TryFrom, ops::Deref},
+    tokio::io::{AsyncRead, AsyncWrite},
 };
+/// An enum of all possible structured data stored within Fixity.
+///
+/// Unstructured data, aka raw bytes, are not represented within this
+/// enum.
+///
+/// Primarily used with [`CacheRead`] and [`CacheWrite`].
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+#[derive(Debug, Clone)]
+pub enum Structured {
+    ProllyTreeNode(prollytree::NodeOwned),
+    ProllyListNode(prollylist::NodeOwned),
+    CommitLogNode(appendlog::LogNode<commitlog::CommitNode>),
+}
 // allowing name repetition to avoid clobbering a std Read or Write trait.
 #[allow(clippy::module_name_repetitions)]
 #[async_trait::async_trait]
 pub trait CacheRead: Sync {
-    type Buf: AsRef<[u8]>;
-    async fn read<A>(&self, addr: A) -> Result<Self::Buf, Error>
+    /// The structured data that the cache can borrow and return in [`CacheRead::read_struct`].
+    ///
+    /// This is an associated type to allow implementers to define borrowed and alternate
+    /// versions of the [`Structured`] data type. Generally this type should reflect [`Structured`],
+    /// but doesn't have to be identical.
+    type OwnedRef: OwnedRef + Send;
+    async fn read_unstructured<A, W>(&self, addr: A, w: W) -> Result<u64, Error>
     where
-        A: AsRef<Addr> + 'static + Send;
+        A: AsRef<Addr> + Into<Addr> + Send,
+        W: AsyncWrite + Unpin + Send;
+    async fn read_structured<A>(&self, addr: A) -> Result<Self::OwnedRef, Error>
+    where
+        A: AsRef<Addr> + Into<Addr> + Send;
+}
+pub trait OwnedRef {
+    // Another lovely place to use GATs, whenever they hit stable, rather than returning a
+    // Self::Ref or &Self::Ref, implementers could return a Self::Ref<'a>, which would be neato.
+    //
+    // The lack of GATs mostly affects low-cost deserialization, ie swapping
+    // `Foo<String>` for `Foo<&'a str>`. So until then, Serde-like impls will
+    // have to be less efficient and duplicate memory on first-read, even if using as_ref().
+    type Ref: Deref<Target = Structured>;
+    fn as_ref_structured(&self) -> &Self::Ref;
+    fn into_owned_structured(self) -> Structured;
+    //fn as_ref<T>(&self) -> &T;
+    //fn into_owned<T>(self) -> T;
 }
 // allowing name repetition to avoid clobbering a std Read or Write trait.
 #[allow(clippy::module_name_repetitions)]
 #[async_trait::async_trait]
 pub trait CacheWrite: Sync {
-    async fn write<A, R>(&self, addr: A, r: R) -> Result<u64, Error>
+    async fn write_unstructured<R>(&self, r: R) -> Result<Addr, Error>
     where
-        A: AsRef<Addr> + 'static + Send,
         R: AsyncRead + Unpin + Send;
+    async fn write_structured<T>(&self, structured: T) -> Result<Addr, Error>
+    where
+        T: Into<Structured> + Send;
 }
 /// A helper trait to allow a single `T` to return references to both a `Workspace` and
 /// a `Cache`.
@@ -31,32 +76,61 @@ pub trait AsCacheRef {
     type Cache: CacheRead + CacheWrite;
     fn as_cache_ref(&self) -> &Self::Cache;
 }
-
-#[async_trait::async_trait]
-impl<T> CacheRead for T
-where
-    T: StorageRead,
-{
-    type Buf = Vec<u8>;
-    async fn read<A>(&self, addr: A) -> Result<Self::Buf, Error>
-    where
-        A: AsRef<Addr> + 'static + Send,
-    {
-        let mut buf = Vec::new();
-        StorageRead::read(self, addr, &mut buf).await?;
-        Ok(buf)
+impl From<prollytree::NodeOwned> for Structured {
+    fn from(t: prollytree::NodeOwned) -> Self {
+        Self::ProllyTreeNode(t)
     }
 }
-#[async_trait::async_trait]
-impl<T> CacheWrite for T
-where
-    T: StorageWrite,
-{
-    async fn write<A, R>(&self, addr: A, r: R) -> Result<u64, Error>
-    where
-        A: AsRef<Addr> + 'static + Send,
-        R: AsyncRead + Unpin + Send,
-    {
-        StorageWrite::write(self, addr, r).await
+impl From<prollylist::NodeOwned> for Structured {
+    fn from(t: prollylist::NodeOwned) -> Self {
+        Self::ProllyListNode(t)
+    }
+}
+impl TryFrom<Structured> for prollytree::NodeOwned {
+    type Error = Error;
+    fn try_from(t: Structured) -> Result<Self, Error> {
+        match t {
+            Structured::ProllyTreeNode(t) => Ok(t),
+            // TODO: this deserves a unique error variant. Possibly a cache-specific error?
+            _ => Err(Error::Unhandled {
+                message: "misaligned cache types".to_owned(),
+            }),
+        }
+    }
+}
+impl<'a> TryFrom<&'a Structured> for &'a prollytree::NodeOwned {
+    type Error = Error;
+    fn try_from(t: &'a Structured) -> Result<&'a prollytree::NodeOwned, Error> {
+        match t {
+            Structured::ProllyTreeNode(t) => Ok(&t),
+            // TODO: this deserves a unique error variant. Possibly a cache-specific error?
+            _ => Err(Error::Unhandled {
+                message: "misaligned cache types".to_owned(),
+            }),
+        }
+    }
+}
+impl TryFrom<Structured> for prollylist::NodeOwned {
+    type Error = Error;
+    fn try_from(t: Structured) -> Result<Self, Error> {
+        match t {
+            Structured::ProllyListNode(t) => Ok(t),
+            // TODO: this deserves a unique error variant. Possibly a cache-specific error?
+            _ => Err(Error::Unhandled {
+                message: "misaligned cache types".to_owned(),
+            }),
+        }
+    }
+}
+impl TryFrom<Structured> for appendlog::LogNode<commitlog::CommitNode> {
+    type Error = Error;
+    fn try_from(t: Structured) -> Result<Self, Error> {
+        match t {
+            Structured::CommitLogNode(t) => Ok(t),
+            // TODO: this deserves a unique error variant. Possibly a cache-specific error?
+            _ => Err(Error::Unhandled {
+                message: "misaligned cache types".to_owned(),
+            }),
+        }
     }
 }

--- a/src/cache/archive_cache.rs
+++ b/src/cache/archive_cache.rs
@@ -1,0 +1,170 @@
+use {
+    crate::{
+        cache::{ArchivedStructured, CacheRead, CacheWrite, OwnedRef, Structured},
+        deser::Deser,
+        storage::{Error, StorageRead, StorageWrite},
+        Addr,
+    },
+    log::warn,
+    rkyv::{
+        archived_value,
+        de::deserializers::AllocDeserializer,
+        ser::{serializers::WriteSerializer, SeekSerializer, Serializer},
+        std_impl::{ArchivedString, ArchivedVec},
+        Archive, Deserialize, Serialize,
+    },
+    std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    },
+    tokio::io::{self, AsyncRead, AsyncWrite},
+};
+pub struct ArchiveCache<S> {
+    storage: S,
+    // TODO: use an LRU or something useful. This is just a simple test of Caching + Archive.
+    // TODO: use a RwLock here. Or ideally a lock-free data structure.
+    cache: Mutex<HashMap<Addr, Arc<Vec<u8>>>>,
+}
+impl<S> ArchiveCache<S> {
+    pub fn new(storage: S) -> Self {
+        Self {
+            storage,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+    /// Write the provided buf to the cache, and internal storage if needed.
+    async fn write_buf(&self, addr: &Addr, buf: Vec<u8>) -> Result<(), Error>
+    where
+        S: StorageWrite + Send,
+    {
+        let buf = Arc::new(buf);
+        let new_to_cache = {
+            let mut cache = self.cache.lock().map_err(|_| Error::Unhandled {
+                message: "cache mutex poisoned".to_owned(),
+            })?;
+            cache.insert(addr.clone(), Arc::clone(&buf)).is_none()
+        };
+        // as an optimization, if it's already in the memory cache we should be able to ignore
+        // writing it to storage.
+        if new_to_cache {
+            let _: u64 = self
+                .storage
+                .write(addr.clone(), &mut buf.as_slice())
+                .await?;
+        }
+        Ok(())
+    }
+    async fn read_buf<A>(&self, addr: A) -> Result<Arc<Vec<u8>>, Error>
+    where
+        S: StorageRead + Send,
+        A: AsRef<Addr> + Into<Addr> + Send,
+    {
+        let addr_ref = addr.as_ref();
+        {
+            let cache = self.cache.lock().map_err(|_| Error::Unhandled {
+                message: "cache mutex poisoned".to_owned(),
+            })?;
+            let buf = cache.get(addr_ref).map(Arc::clone);
+            if let Some(buf) = buf {
+                return Ok(Arc::clone(&buf));
+            }
+        }
+        // we could have a concurrency issue here, where we read from storage twice.
+        // This is low-risk (ie won't corrupt data/etc), and should be tweaked based on
+        // what results in better performance.
+        // Optimizing for duplicate cache inserts vs holding the lock longer.
+        // Possibly even keeping some type of LockState to have short lock length?
+        // /shrug, bench concern for down the road.
+        let mut buf = Vec::new();
+        let _: u64 = StorageRead::read(&self.storage, addr_ref.clone(), &mut buf).await?;
+        let mut cache = self.cache.lock().map_err(|_| Error::Unhandled {
+            message: "cache mutex poisoned".to_owned(),
+        })?;
+        let buf = Arc::new(buf);
+        if let Some(_) = cache.insert(addr_ref.clone(), Arc::clone(&buf)) {
+            warn!("cache inserted twice, needless storage read");
+        }
+        Ok(buf)
+    }
+}
+#[async_trait::async_trait]
+impl<S> CacheRead for ArchiveCache<S>
+where
+    S: StorageRead + Send,
+{
+    type OwnedRef = ArchiveBytes;
+    async fn read_unstructured<A, W>(&self, addr: A, mut w: W) -> Result<u64, Error>
+    where
+        A: AsRef<Addr> + Into<Addr> + Send,
+        W: AsyncWrite + Unpin + Send,
+    {
+        let buf = self.read_buf(addr).await?;
+        let len = io::copy(&mut buf.as_slice(), &mut w).await?;
+        Ok(len)
+    }
+    async fn read_structured<A>(&self, addr: A) -> Result<Self::OwnedRef, Error>
+    where
+        A: AsRef<Addr> + Into<Addr> + Send,
+    {
+        let buf = self.read_buf(addr).await?;
+        Ok(ArchiveBytes(buf))
+    }
+}
+pub struct ArchiveBytes(Arc<Vec<u8>>);
+impl OwnedRef for ArchiveBytes {
+    fn as_ref(&self) -> &ArchivedStructured {
+        unsafe {
+            archived_value::<Structured>(
+                self.0.as_slice(),
+                // we're only serializing to the beginning of the buf.
+                0,
+            )
+        }
+    }
+    fn into_owned(self) -> Structured {
+        let archived = self.as_ref();
+        let mut deserializer = AllocDeserializer;
+        let deserialized = archived.deserialize(&mut deserializer).unwrap();
+        deserialized
+    }
+}
+#[async_trait::async_trait]
+impl<S> CacheWrite for ArchiveCache<S>
+where
+    S: StorageWrite + Send,
+{
+    async fn write_unstructured<R>(&self, mut r: R) -> Result<Addr, Error>
+    where
+        R: AsyncRead + Unpin + Send,
+    {
+        let mut buf = Vec::new();
+        let _: u64 = io::copy(&mut r, &mut buf).await?;
+        let addr = Addr::hash(&buf);
+        self.write_buf(&addr, buf).await?;
+        Ok(addr)
+    }
+    async fn write_structured<T>(&self, structured: T) -> Result<Addr, Error>
+    where
+        T: Into<Structured> + Send,
+    {
+        let structured = structured.into();
+        let addr = {
+            let deser_buf = Deser::default().to_vec(&structured).unwrap();
+            Addr::hash(&deser_buf)
+        };
+        let mut serializer = WriteSerializer::new(std::io::Cursor::new(Vec::new()));
+        let pos: usize = serializer
+            .archive_root(&structured)
+            .map_err(|err| Error::Unhandled {
+                message: format!("Archive serialization: {}", err),
+            })?;
+        if pos != 0 {
+            return Err(Error::Unhandled {
+                message: "archive position unexpectedly not zero".to_owned(),
+            });
+        }
+        let buf = serializer.into_inner().into_inner();
+        self.write_buf(&addr, buf).await?;
+        Ok(addr)
+    }
+}

--- a/src/cache/deser_cache.rs
+++ b/src/cache/deser_cache.rs
@@ -1,0 +1,230 @@
+use {
+    crate::{
+        cache::{CacheRead, CacheWrite, OwnedRef},
+        deser::Deser,
+        primitive::Object,
+        storage::{Error, StorageRead, StorageWrite},
+        Addr,
+    },
+    log::debug,
+    std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    },
+    tokio::io::{self, AsyncRead, AsyncWrite},
+};
+#[derive(Debug, Hash, Eq, PartialEq)]
+enum CacheKey {
+    Object(Addr),
+    Bytes(Addr),
+}
+#[derive(Debug)]
+enum CacheValue {
+    Object(Arc<Object>),
+    Bytes(Arc<Vec<u8>>),
+}
+pub struct DeserCache<S> {
+    deser: Deser,
+    storage: S,
+    // TODO: use an LRU or something useful. This is just a simple test of Caching + Deser.
+    // TODO: use a RwLock here. Or ideally a lock-free data structure.
+    cache: Mutex<HashMap<CacheKey, CacheValue>>,
+}
+impl<S> DeserCache<S> {
+    pub fn new(storage: S) -> Self {
+        Self {
+            // TODO: use a passed in deser.
+            deser: Deser::default(),
+            storage,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+}
+#[async_trait::async_trait]
+impl<S> CacheRead for DeserCache<S>
+where
+    S: StorageRead + Send,
+{
+    type OwnedRef = Arc<Object>;
+    async fn read_unstructured<A, W>(&self, addr: A, mut w: W) -> Result<u64, Error>
+    where
+        A: AsRef<Addr> + Into<Addr> + Send,
+        W: AsyncWrite + Unpin + Send,
+    {
+        let addr_ref = addr.as_ref();
+        let buf = {
+            let cache = self.cache.lock().map_err(|_| Error::Unhandled {
+                message: "cache mutex poisoned".to_owned(),
+            })?;
+            cache
+                // TODO: impl Borrow for CacheKey, to avoid this Addr clone.
+                .get(&CacheKey::Bytes(addr_ref.clone()))
+                .and_then(|k| match k {
+                    CacheValue::Bytes(buf) => Some(Arc::clone(&buf)),
+                    CacheValue::Object(_) => None,
+                })
+        };
+        if let Some(buf) = buf {
+            let len = io::copy(&mut buf.as_slice(), &mut w).await?;
+            return Ok(len);
+        }
+        // we could have a concurrency issue here, where we read from storage twice.
+        // This is low-risk (ie won't corrupt data/etc), and should be tweaked based on
+        // what results in better performance.
+        // Optimizing for duplicate cache inserts vs holding the lock longer.
+        // Possibly even keeping some type of LockState to have short lock length?
+        // /shrug, bench concern for down the road.
+        let buf = {
+            let mut buf = Vec::new();
+            let _: u64 = StorageRead::read(&self.storage, addr_ref.clone(), &mut buf).await?;
+            Arc::new(buf)
+        };
+        {
+            let mut cache = self.cache.lock().map_err(|_| Error::Unhandled {
+                message: "cache mutex poisoned".to_owned(),
+            })?;
+            let prev = cache.insert(
+                CacheKey::Bytes(addr_ref.clone()),
+                CacheValue::Bytes(Arc::clone(&buf)),
+            );
+            if prev.is_some() {
+                debug!("cache inserted twice, needless storage read");
+            }
+        }
+        let len = io::copy(&mut buf.as_slice(), &mut w).await?;
+        Ok(len)
+    }
+    async fn read_structured<A>(&self, addr: A) -> Result<Self::OwnedRef, Error>
+    where
+        A: AsRef<Addr> + Into<Addr> + Send,
+    {
+        let addr_ref = addr.as_ref();
+        {
+            let cache = self.cache.lock().map_err(|_| Error::Unhandled {
+                message: "cache mutex poisoned".to_owned(),
+            })?;
+            // TODO: impl Borrow for CacheKey, to avoid this Addr clone.
+            if let Some(CacheValue::Object(obj)) = cache.get(&CacheKey::Object(addr_ref.clone())) {
+                return Ok(Arc::clone(&obj));
+            }
+        }
+        // we could have a concurrency issue here, where we read from storage twice.
+        // This is low-risk (ie won't corrupt data/etc), and should be tweaked based on
+        // what results in better performance.
+        // Optimizing for duplicate cache inserts vs holding the lock longer.
+        // Possibly even keeping some type of LockState to have short lock length?
+        // /shrug, bench concern for down the road.
+        let obj = {
+            let buf = {
+                let mut buf = Vec::new();
+                let _: u64 = StorageRead::read(&self.storage, addr_ref.clone(), &mut buf).await?;
+                buf
+            };
+            let obj = self
+                .deser
+                .from_slice::<Object>(&buf)
+                .map_err(|err| Error::Unhandled {
+                    message: format!("deser: {}", err),
+                })?;
+            Arc::new(obj)
+        };
+        {
+            let mut cache = self.cache.lock().map_err(|_| Error::Unhandled {
+                message: "cache mutex poisoned".to_owned(),
+            })?;
+            let cache_value = cache.insert(
+                CacheKey::Object(addr_ref.clone()),
+                CacheValue::Object(Arc::clone(&obj)),
+            );
+            if cache_value.is_some() {
+                debug!("cache inserted twice, needless storage read");
+            }
+        }
+        Ok(obj)
+    }
+}
+impl OwnedRef for Arc<Object> {
+    type Ref = Self;
+    fn as_ref_structured(&self) -> &Self::Ref {
+        self
+    }
+    fn into_owned_structured(self) -> Object {
+        use std::ops::Deref;
+        (*self.deref()).clone()
+    }
+}
+#[async_trait::async_trait]
+impl<S> CacheWrite for DeserCache<S>
+where
+    S: StorageWrite + Send,
+{
+    async fn write_unstructured<R>(&self, mut r: R) -> Result<Addr, Error>
+    where
+        R: AsyncRead + Unpin + Send,
+    {
+        let buf = {
+            let mut buf = Vec::new();
+            let _: u64 = io::copy(&mut r, &mut buf).await?;
+            Arc::new(buf)
+        };
+        let addr = Addr::hash(buf.as_ref());
+        let new_to_cache = {
+            let mut cache = self.cache.lock().map_err(|_| Error::Unhandled {
+                message: "cache mutex poisoned".to_owned(),
+            })?;
+            cache
+                .insert(
+                    CacheKey::Bytes(addr.clone()),
+                    CacheValue::Bytes(Arc::clone(&buf)),
+                )
+                .is_none()
+        };
+        // as an optimization, if it's already in the memory cache we should be able to ignore
+        // writing it to storage.
+        //
+        // :WARN: If this fails the cache won't be invalidated, we could/should defer writing to
+        // cache until after failure.
+        if new_to_cache {
+            let _: u64 = self
+                .storage
+                .write(addr.clone(), &mut buf.as_slice())
+                .await?;
+        }
+        Ok(addr)
+    }
+    async fn write_structured<T>(&self, object: T) -> Result<Addr, Error>
+    where
+        T: Into<Object> + Send,
+    {
+        let object = object.into();
+        let buf = Deser::default()
+            .to_vec(&object)
+            .map_err(|err| Error::Unhandled {
+                message: format!("deser: {}", err),
+            })?;
+        let addr = Addr::hash(&buf);
+        let new_to_cache = {
+            let mut cache = self.cache.lock().map_err(|_| Error::Unhandled {
+                message: "cache mutex poisoned".to_owned(),
+            })?;
+            cache
+                .insert(
+                    CacheKey::Object(addr.clone()),
+                    CacheValue::Object(Arc::new(object)),
+                )
+                .is_none()
+        };
+        // as an optimization, if it's already in the memory cache we should be able to ignore
+        // writing it to storage.
+        //
+        // :WARN: If this fails the cache won't be invalidated, we could/should defer writing to
+        // cache until after failure.
+        if new_to_cache {
+            let _: u64 = self
+                .storage
+                .write(addr.clone(), &mut buf.as_slice())
+                .await?;
+        }
+        Ok(addr)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
     // clippy::pedantic
     // clippy::nursery
     // clippy::cargo,
+    clippy::unwrap_used,
 )]
 // This warning makes less sense with enum-flavored error handling,
 // which this library is using.

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -6,6 +6,7 @@ pub mod commitlog;
 pub mod prollylist;
 pub mod prollytree;
 pub use {
+    crate::cache::Structured as Object,
     appendlog::AppendLog,
     bytes::{Create as BytesCreate, Read as BytesRead},
     commitlog::CommitLog,

--- a/src/primitive/appendlog.rs
+++ b/src/primitive/appendlog.rs
@@ -1,6 +1,7 @@
 use crate::{
-    cache::{CacheRead, CacheWrite},
-    deser::{Deser, Deserialize, Serialize},
+    cache::{CacheRead, CacheWrite, OwnedRef, Structured},
+    primitive::commitlog,
+    storage::Error as StorageError,
     Addr, Error,
 };
 pub struct LogContainer<'a, T> {
@@ -12,17 +13,55 @@ pub struct LogContainer<'a, T> {
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
+#[derive(Debug, Clone)]
 pub struct LogNode<T> {
     pub inner: T,
     pub prev: Option<Addr>,
 }
+/// An awkward interface, needed to allow the `T` in `LogNode<T>` to
+/// resolve to a concrete [`Structured`] variant.
+///
+/// With this type, `AppendLog` extensions like `CommitLog` can implement `Into<LogInnerType>`
+/// and allow AppendLog to do the conversion to a proper `Structured` variant.
+#[derive(Debug)]
+pub enum LogInnerType {
+    Commit(commitlog::CommitNode),
+}
+impl From<commitlog::CommitNode> for LogInnerType {
+    fn from(n: commitlog::CommitNode) -> LogInnerType {
+        LogInnerType::Commit(n)
+    }
+}
+impl<T> From<LogNode<T>> for Structured
+where
+    T: Into<LogInnerType>,
+{
+    fn from(log_node: LogNode<T>) -> Self {
+        let LogNode { inner, prev } = log_node;
+        // single variant for now, idiomatic..
+        let LogInnerType::Commit(inner) = inner.into();
+        Structured::CommitLogNode(LogNode { inner, prev })
+    }
+}
+pub trait LogNodeFrom<T>: Sized {
+    fn log_node_from(t: T) -> Option<LogNode<Self>>;
+}
+impl LogNodeFrom<Structured> for commitlog::CommitNode {
+    fn log_node_from(t: Structured) -> Option<LogNode<Self>> {
+        if let Structured::CommitLogNode(node) = t {
+            Some(node)
+        } else {
+            None
+        }
+    }
+}
 pub struct AppendLog<'s, C> {
-    storage: &'s C,
+    cache: &'s C,
     addr: Option<Addr>,
 }
 impl<'s, C> AppendLog<'s, C> {
-    pub fn new(storage: &'s C, addr: Option<Addr>) -> Self {
-        Self { storage, addr }
+    pub fn new(cache: &'s C, addr: Option<Addr>) -> Self {
+        Self { cache, addr }
     }
 }
 impl<'s, C> AppendLog<'s, C>
@@ -31,17 +70,14 @@ where
 {
     pub async fn append<T>(&mut self, inner: T) -> Result<Addr, Error>
     where
-        T: Serialize + Deserialize,
+        T: Into<LogInnerType> + Send,
     {
-        let buf = {
-            let node = LogNode {
-                inner,
-                prev: self.addr.clone(),
-            };
-            Deser::default().to_vec(&node)?
+        let node = LogNode {
+            inner,
+            prev: self.addr.clone(),
         };
-        let addr = Addr::hash(&buf);
-        self.storage.write(addr.clone(), &*buf).await?;
+        // let addr = Addr::hash(&buf);
+        let addr = self.cache.write_structured(node).await?;
         let _ = self.addr.replace(addr.clone());
         Ok(addr)
     }
@@ -52,19 +88,27 @@ where
 {
     pub async fn first_container<T>(&self) -> Result<Option<LogContainer<'_, LogNode<T>>>, Error>
     where
-        T: Deserialize,
+        T: LogNodeFrom<Structured>,
     {
         let addr = match self.addr.as_ref() {
-            None => return Ok(None),
             Some(addr) => addr,
+            None => return Ok(None),
         };
-        let buf = self.storage.read(addr.clone()).await?;
-        let node = Deser::default().from_slice(buf.as_ref())?;
+        let owned_ref = self.cache.read_structured(addr).await?;
+        // TODO: the design of AppendLog makes using OwnedRef::Ref really awkward,
+        // and needs to be redesigned. However appendlog is not heavily used currently,
+        // only commits, so it's a low perf impact to just own the value immediately.
+        let node = T::log_node_from(owned_ref.into_owned_structured())
+            // TODO: this deserves a unique error variant. Possibly a cache-specific error?
+            // Also, this is going to likely be a CacheError in the future?
+            .ok_or_else(|| StorageError::Unhandled {
+                message: "misaligned cache types".to_owned(),
+            })?;
         Ok(Some(LogContainer { addr, node }))
     }
     pub async fn first<T>(&self) -> Result<Option<LogNode<T>>, Error>
     where
-        T: Deserialize,
+        T: LogNodeFrom<Structured>,
     {
         let container = self.first_container().await?;
         Ok(container.map(|LogContainer { node, .. }| node))

--- a/src/primitive/commitlog.rs
+++ b/src/primitive/commitlog.rs
@@ -11,7 +11,7 @@ use {
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CommitNode {
     pub timestamp: i64,
     pub content: Addr,

--- a/src/primitive/prollylist.rs
+++ b/src/primitive/prollylist.rs
@@ -11,6 +11,7 @@ pub type NodeOwned = Node<Value, Addr>;
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
+#[derive(Debug, Clone)]
 pub enum Node<Value, Addr> {
     Branch(Vec<Addr>),
     Leaf(Vec<Value>),

--- a/src/primitive/prollylist/refimpl/create.rs
+++ b/src/primitive/prollylist/refimpl/create.rs
@@ -15,16 +15,16 @@ use {
     std::mem,
 };
 pub struct Create<'s, C> {
-    storage: &'s C,
+    cache: &'s C,
     roller: Roller,
 }
 impl<'s, C> Create<'s, C> {
-    pub fn new(storage: &'s C) -> Self {
-        Self::with_roller(storage, RollerConfig::default())
+    pub fn new(cache: &'s C) -> Self {
+        Self::with_roller(cache, RollerConfig::default())
     }
-    pub fn with_roller(storage: &'s C, roller_config: RollerConfig) -> Self {
+    pub fn with_roller(cache: &'s C, roller_config: RollerConfig) -> Self {
         Self {
-            storage,
+            cache,
             roller: Roller::with_config(roller_config),
         }
     }
@@ -91,15 +91,13 @@ where
         }
     }
     async fn write_node(&self, node: NodeOwned) -> Result<Addr, Error> {
-        let node_bytes = Deser::default().to_vec(&node)?;
-        let node_addr = Addr::hash(&node_bytes);
-        self.storage.write(node_addr.clone(), &*node_bytes).await?;
+        let node_addr = self.cache.write_structured(node).await?;
         Ok(node_addr)
     }
 }
 #[cfg(test)]
 pub mod test {
-    use {super::*, crate::storage::Memory};
+    use {super::*, crate::Fixity};
     /// A smaller value to use with the roller, producing smaller average block sizes.
     const TEST_PATTERN: u32 = (1 << 8) - 1;
     #[tokio::test]
@@ -113,8 +111,8 @@ pub mod test {
         let contents = vec![(0u32..20), (0..200), (0..2_000)];
         for content in contents {
             let content = content.map(Value::from).collect::<Vec<_>>();
-            let storage = Memory::new();
-            let tree = Create::with_roller(&storage, RollerConfig::with_pattern(TEST_PATTERN));
+            let cache = Fixity::memory().into_cache();
+            let tree = Create::with_roller(&cache, RollerConfig::with_pattern(TEST_PATTERN));
             let addr = tree.with_vec(content).await.unwrap();
             dbg!(addr);
         }

--- a/src/primitive/prollylist/refimpl/read.rs
+++ b/src/primitive/prollylist/refimpl/read.rs
@@ -1,9 +1,11 @@
-use crate::{
-    cache::CacheRead,
-    deser::Deser,
-    primitive::prollylist::{Node, NodeOwned},
-    value::{Addr, Value},
-    Error,
+use {
+    crate::{
+        cache::{CacheRead, OwnedRef},
+        primitive::prollylist::Node,
+        value::{Addr, Value},
+        Error,
+    },
+    std::convert::TryInto,
 };
 pub struct Read<'s, C> {
     storage: &'s C,
@@ -25,8 +27,8 @@ where
     #[async_recursion::async_recursion]
     async fn recursive_to_vec(&self, addr: Addr) -> Result<Vec<Value>, Error> {
         let node = {
-            let buf = self.storage.read(addr.clone()).await?;
-            Deser::default().from_slice::<NodeOwned>(buf.as_ref())?
+            let owned_ref = self.storage.read_structured(&addr).await?;
+            owned_ref.into_owned_structured().try_into()?
         };
         match node {
             Node::Leaf(v) => Ok(v),
@@ -46,7 +48,7 @@ pub mod test {
         super::*,
         crate::{
             primitive::{prollylist::refimpl::Create, prollytree::roller::Config as RollerConfig},
-            storage::Memory,
+            Fixity,
         },
     };
     /// A smaller value to use with the roller, producing smaller average block sizes.
@@ -62,10 +64,10 @@ pub mod test {
         let contents = vec![(0u32..20), (0..200), (0..2_000)];
         for content in contents {
             let written_values = content.map(|v| Value::from(v)).collect::<Vec<_>>();
-            let storage = Memory::new();
-            let tree = Create::with_roller(&storage, RollerConfig::with_pattern(TEST_PATTERN));
+            let cache = Fixity::memory().into_cache();
+            let tree = Create::with_roller(&cache, RollerConfig::with_pattern(TEST_PATTERN));
             let addr = tree.with_vec(written_values.clone()).await.unwrap();
-            let read_values = Read::new(&storage, addr).to_vec().await.unwrap();
+            let read_values = Read::new(&cache, addr).to_vec().await.unwrap();
             assert_eq!(
                 written_values, read_values,
                 "expected read values to match written values"

--- a/src/primitive/prollytree.rs
+++ b/src/primitive/prollytree.rs
@@ -7,17 +7,14 @@ pub mod roller;
 // cursor_create::CursorCreate,
 // cursor_read::CursorRead,
 // lru_read::LruRead,
-
-pub(crate) const ONE_LEN_BLOCK_WARNING: &str =
-    "writing key & value that exceeds block size, this is highly inefficient";
-
 use crate::{
     value::{Addr, Key, Value},
     Error,
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-
+pub(crate) const ONE_LEN_BLOCK_WARNING: &str =
+    "writing key & value that exceeds block size, this is highly inefficient";
 /// An alias to a [`Node`] with owned parameters.
 pub type NodeOwned = Node<Key, Value, Addr>;
 /// The lowest storage block within Fixity, a Node within a Prolly Tree.
@@ -26,6 +23,7 @@ pub type NodeOwned = Node<Key, Value, Addr>;
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Node<Key, Value, Addr> {
     Branch(Vec<(Key, Addr)>),
     Leaf(Vec<(Key, Value)>),

--- a/src/primitive/prollytree/refimpl/update.rs
+++ b/src/primitive/prollytree/refimpl/update.rs
@@ -16,17 +16,17 @@ pub enum Change {
     Remove,
 }
 pub struct Update<'s, C> {
-    storage: &'s C,
+    cache: &'s C,
     root_addr: Addr,
     roller_config: RollerConfig,
 }
 impl<'s, C> Update<'s, C> {
-    pub fn new(storage: &'s C, root_addr: Addr) -> Self {
-        Self::with_roller(storage, root_addr, RollerConfig::default())
+    pub fn new(cache: &'s C, root_addr: Addr) -> Self {
+        Self::with_roller(cache, root_addr, RollerConfig::default())
     }
-    pub fn with_roller(storage: &'s C, root_addr: Addr, roller_config: RollerConfig) -> Self {
+    pub fn with_roller(cache: &'s C, root_addr: Addr, roller_config: RollerConfig) -> Self {
         Self {
-            storage,
+            cache,
             root_addr,
             roller_config,
         }
@@ -43,7 +43,7 @@ where
     ///
     /// # Errors
     ///
-    /// If the provided vec contains non-unique keys or any writes to storage fail
+    /// If the provided vec contains non-unique keys or any writes to cache fail
     /// an error is returned.
     pub async fn with_vec(self, mut changes: Vec<(Key, Change)>) -> Result<Addr, Error> {
         {
@@ -57,7 +57,7 @@ where
                 });
             }
         }
-        let all_kvs = Read::new(self.storage, self.root_addr.clone())
+        let all_kvs = Read::new(self.cache, self.root_addr.clone())
             .to_vec()
             .await?;
         let mut kvs = all_kvs
@@ -88,14 +88,14 @@ where
         // kvs is now the modified vec of keyvalues and can be constructed as an entire
         // new tree. Since each block is deterministic, this effectively mutates the source
         // tree with the least lines of code.
-        Create::with_roller(self.storage, self.roller_config)
+        Create::with_roller(self.cache, self.roller_config)
             .with_hashmap(kvs)
             .await
     }
 }
 #[cfg(test)]
 pub mod test {
-    use {super::*, crate::storage::Memory};
+    use {super::*, crate::Fixity};
     /// A smaller value to use with the roller, producing smaller average block sizes.
     const TEST_PATTERN: u32 = (1 << 8) - 1;
     #[tokio::test]
@@ -123,9 +123,9 @@ pub mod test {
                 .flatten()
                 .map(|i| (Key::from(i), Value::from(i)))
                 .collect::<Vec<_>>();
-            let storage = Memory::new();
+            let cache = Fixity::memory().into_cache();
             let source_addr = {
-                let tree = Create::with_roller(&storage, RollerConfig::with_pattern(TEST_PATTERN));
+                let tree = Create::with_roller(&cache, RollerConfig::with_pattern(TEST_PATTERN));
                 let source_kvs = source_kvs
                     .map(|i| (i, i))
                     .map(|(k, v)| (Key::from(k), Value::from(v)))
@@ -134,7 +134,7 @@ pub mod test {
             };
             let got_addr = {
                 Update::with_roller(
-                    &storage,
+                    &cache,
                     source_addr,
                     RollerConfig::with_pattern(TEST_PATTERN),
                 )
@@ -150,13 +150,10 @@ pub mod test {
                 .await
                 .unwrap()
             };
-            let got_kvs = Read::new(&storage, got_addr.clone())
-                .to_vec()
-                .await
-                .unwrap();
+            let got_kvs = Read::new(&cache, got_addr.clone()).to_vec().await.unwrap();
             assert_eq!(expected_kvs, got_kvs);
             let expected_addr = {
-                Create::with_roller(&storage, RollerConfig::with_pattern(TEST_PATTERN))
+                Create::with_roller(&cache, RollerConfig::with_pattern(TEST_PATTERN))
                     .with_vec(expected_kvs)
                     .await
                     .unwrap()

--- a/src/ref_type_test.rs
+++ b/src/ref_type_test.rs
@@ -1,0 +1,364 @@
+//! Delete me.
+
+use {
+    rkyv::{
+        archived_value,
+        de::deserializers::AllocDeserializer,
+        ser::{serializers::WriteSerializer, Serializer},
+        std_impl::{ArchivedString, ArchivedVec},
+        Archive, Deserialize, Serialize,
+    },
+    std::borrow::Borrow,
+};
+pub trait AsAddrRef {
+    fn as_addr_ref<'a>(&'a self) -> AddrRef<'a>;
+}
+pub trait AsScalarRef {
+    fn as_scalar_ref<'a>(&'a self) -> ScalarRef<'a>;
+}
+pub trait AsValueRef {
+    type Scalar: AsScalarRef;
+    fn as_value_ref<'a>(&'a self) -> ValueRef<'a, Self::Scalar>;
+}
+impl<T> AsValueRef for &T
+where
+    T: AsValueRef,
+{
+    type Scalar = T::Scalar;
+    fn as_value_ref<'a>(&'a self) -> ValueRef<'a, Self::Scalar> {
+        (*self).as_value_ref()
+    }
+}
+pub trait AsScalarSlice {
+    type Scalar: AsScalarRef;
+    fn as_scalar_slice<'a>(&'a self) -> &'a [Self::Scalar];
+}
+impl AsScalarSlice for Vec<ScalarOwned> {
+    type Scalar = ScalarOwned;
+    fn as_scalar_slice<'a>(&'a self) -> &'a [Self::Scalar] {
+        self.as_ref()
+    }
+}
+impl<T> AsScalarSlice for &T
+where
+    T: AsScalarSlice,
+{
+    type Scalar = T::Scalar;
+    fn as_scalar_slice<'a>(&'a self) -> &'a [Self::Scalar] {
+        (*self).as_scalar_slice()
+    }
+}
+impl<T> AsScalarSlice for rkyv::std_impl::ArchivedVec<T>
+where
+    T: AsScalarRef,
+{
+    type Scalar = T;
+    fn as_scalar_slice<'a>(&'a self) -> &'a [Self::Scalar] {
+        self.as_ref()
+    }
+}
+/*
+impl<T, U> AsScalarRef for T
+where
+    T: std::ops::Deref<Target = U>,
+    U: AsScalarRef,
+{
+    fn as_scalar_ref<'a>(&'a self) -> ScalarRef<'a> {
+        self.as_scalar_ref()
+    }
+}
+*/
+impl<T> AsScalarRef for &T
+where
+    T: AsScalarRef,
+{
+    fn as_scalar_ref<'a>(&'a self) -> ScalarRef<'a> {
+        (*self).as_scalar_ref()
+    }
+}
+pub trait AsBranchRef {
+    type Key: AsValueRef;
+    type Addr: AsAddrRef;
+    fn as_branch_ref(&self) -> &[(Self::Key, Self::Addr)];
+}
+impl AsBranchRef for Vec<(KeyOwned, Addr)> {
+    type Key = KeyOwned;
+    type Addr = Addr;
+    fn as_branch_ref(&self) -> &[(Self::Key, Self::Addr)] {
+        self.as_ref()
+    }
+}
+impl AsBranchRef for ArchivedVec<(KeyArchived, ArchivedAddr)> {
+    type Key = KeyArchived;
+    type Addr = ArchivedAddr;
+    fn as_branch_ref(&self) -> &[(Self::Key, Self::Addr)] {
+        self.as_ref()
+    }
+}
+pub trait AsNodeRef {
+    type Scalar: AsScalarRef;
+    fn as_node_ref<'a>(&'a self) -> NodeRef<'a, Self::Scalar>;
+}
+#[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub struct Addr(pub [u8; 32]);
+impl AsRef<Addr> for Addr {
+    fn as_ref(&self) -> &Addr {
+        &self
+    }
+}
+impl AsAddrRef for Addr {
+    fn as_addr_ref<'a>(&'a self) -> AddrRef<'a> {
+        AddrRef(&self.0)
+    }
+}
+impl AsAddrRef for ArchivedAddr {
+    fn as_addr_ref<'a>(&'a self) -> AddrRef<'a> {
+        AddrRef(&self.0)
+    }
+}
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AddrRef<'a>(pub &'a [u8; 32]);
+#[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub enum Scalar<ADDR, STRING> {
+    Addr(ADDR),
+    Uint32(u32),
+    String(STRING),
+}
+pub type ScalarOwned = Scalar<Addr, String>;
+pub type ScalarRef<'a> = Scalar<AddrRef<'a>, &'a str>;
+pub type ScalarArchived = Scalar<ArchivedAddr, ArchivedString>;
+impl<ADDR, STRING> AsScalarRef for Scalar<ADDR, STRING>
+where
+    ADDR: AsAddrRef,
+    STRING: AsRef<str>,
+{
+    fn as_scalar_ref<'a>(&'a self) -> ScalarRef<'a> {
+        match self {
+            Self::Addr(addr) => Scalar::Addr(addr.as_addr_ref()),
+            Self::Uint32(i) => Scalar::Uint32(*i),
+            Self::String(s) => Scalar::String(s.as_ref()),
+        }
+    }
+}
+impl<ADDR, STRING> AsScalarRef for ArchivedScalar<ADDR, STRING>
+where
+    ADDR: Archive,
+    ADDR::Archived: AsAddrRef,
+    STRING: Archive,
+    STRING::Archived: Borrow<str>,
+{
+    fn as_scalar_ref<'a>(&'a self) -> ScalarRef<'a> {
+        match self {
+            Self::Addr(addr) => Scalar::Addr(addr.as_addr_ref()),
+            Self::Uint32(i) => Scalar::Uint32(*i),
+            Self::String(s) => Scalar::String(s.borrow()),
+        }
+    }
+}
+#[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub enum Value<ADDR, STRING, VEC> {
+    Addr(ADDR),
+    Uint32(u32),
+    String(STRING),
+    Vec(VEC),
+}
+pub type ValueOwned = Value<Addr, String, Vec<ScalarOwned>>;
+pub type ValueRef<'a, SCALAR> = Value<AddrRef<'a>, &'a str, &'a [SCALAR]>;
+pub type ValueArchived = Value<ArchivedAddr, ArchivedString, ArchivedVec<ScalarArchived>>;
+impl<ADDR, STRING, VEC> AsValueRef for Value<ADDR, STRING, VEC>
+where
+    ADDR: AsAddrRef,
+    STRING: AsRef<str>,
+    VEC: AsScalarSlice,
+{
+    type Scalar = VEC::Scalar;
+    fn as_value_ref<'a>(&'a self) -> ValueRef<'a, Self::Scalar> {
+        match self {
+            Self::Addr(addr) => Value::Addr(addr.as_addr_ref()),
+            Self::Uint32(i) => Value::Uint32(*i),
+            Self::String(s) => Value::String(s.as_ref()),
+            Self::Vec(v) => Value::Vec(v.as_scalar_slice()),
+        }
+    }
+}
+impl<ADDR, STRING, VEC> AsValueRef for ArchivedValue<ADDR, STRING, VEC>
+where
+    ADDR: Archive,
+    ADDR::Archived: AsAddrRef,
+    STRING: Archive,
+    STRING::Archived: std::ops::Deref<Target = str>,
+    VEC: Archive,
+    VEC::Archived: AsScalarSlice,
+{
+    type Scalar = <<VEC as Archive>::Archived as AsScalarSlice>::Scalar;
+    fn as_value_ref<'a>(&'a self) -> ValueRef<'a, Self::Scalar> {
+        match self {
+            Self::Addr(addr) => Value::Addr(addr.as_addr_ref()),
+            Self::Uint32(i) => Value::Uint32(*i),
+            Self::String(s) => Value::String(s.as_ref()),
+            Self::Vec(v) => Value::Vec(v.as_scalar_slice()),
+        }
+    }
+}
+pub type Key<ADDR, STRING, VEC> = Value<ADDR, STRING, VEC>;
+pub type KeyOwned = ValueOwned;
+pub type KeyRef<'a, SCALAR> = ValueRef<'a, SCALAR>;
+pub type KeyArchived = Key<ArchivedAddr, ArchivedString, ArchivedVec<ScalarArchived>>;
+#[derive(Archive, Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub enum Node<BranchVec, LeafVec> {
+    Branch(BranchVec),
+    Leaf(LeafVec),
+}
+pub type NodeOwned = Node<Vec<(KeyOwned, Addr)>, Vec<(KeyOwned, ValueOwned)>>;
+pub type NodeRef<'a, SCALAR> =
+    Node<&'a [(KeyRef<'a, SCALAR>, &'a Addr)], &'a [(KeyRef<'a, SCALAR>, ValueRef<'a, SCALAR>)]>;
+/*
+impl<BranchVec, LeafVec> AsNodeRef for Node<BranchVec, LeafVec>
+    where
+        BranchVec: AsRef<[(KeyRef<'a>, &'a Addr)]>,
+        LeafVec: AsRef<[(KeyRef<'a>, ValueRef<'a>)]>,
+{
+    type Scalar = VEC::Scalar;
+    fn as_node_ref<'a>(&'a self) -> NodeRef<'a, SCALAR>
+    {
+        match self {
+            Self::Branch(v) => NodeRef::Branch(v.as_ref()),
+            Self::Leaf(v) => NodeRef::Leaf(v.as_ref()),
+        }
+    }
+}
+*/
+// impl AsRef<Node<ArchivedNode
+impl<B, L> AsRef<Node<B, L>> for Node<B, L> {
+    fn as_ref(&self) -> &Node<B, L> {
+        &self
+    }
+}
+/*
+fn print_node<ADDR, STRING, VecScalar, BranchVec, LeafVec, T>(t: T)
+where
+    ADDR: AsRef<Addr>,
+    STRING: AsRef<str>,
+    VecScalar: AsRef<[Scalar<ADDR, STRING>]>,
+    BranchVec: AsRef<[(Key<ADDR, STRING, VecScalar>, ADDR)]>,
+    LeafVec: AsRef<[(Key<ADDR, STRING, VecScalar>, Value<ADDR, STRING, VecScalar>)]>,
+    T: AsRef<Node<BranchVec, LeafVec>>,
+{
+    match t.as_ref() {
+        Node::Branch(v) => v.as_ref().iter().for_each(|(key, addr)| {
+            println!("branch({:?}, {:?})", key.string().as_ref(), addr.as_ref())
+        }),
+        Node::Leaf(v) => v.as_ref().iter().for_each(|(key, value)| {
+            println!(
+                "leaf({:?}, {:?})",
+                key.string().as_ref(),
+                value.string().as_ref()
+            )
+        }),
+    }
+}
+*/
+fn print_branch_tuple<T>(t: T)
+where
+    T: AsBranchRef,
+{
+    for (key, addr) in t.as_branch_ref() {
+        println!("got addr, {:?}", addr.as_addr_ref());
+        match key.as_value_ref() {
+            Key::Addr(addr) => println!("got addr, {:?}", addr),
+            Key::Uint32(i) => println!("got int, {}", i),
+            Key::String(s) => println!("got string, {:?}", s),
+            Key::Vec(v) => v
+                .iter()
+                .for_each(|s| println!("got vec scalar, {:?}", s.as_scalar_ref())),
+        }
+    }
+}
+fn print_value<T>(t: T)
+where
+    T: AsValueRef,
+{
+    match t.as_value_ref() {
+        Value::Addr(addr) => println!("got addr, {:?}", addr),
+        Value::Uint32(i) => println!("got int, {}", i),
+        Value::String(s) => println!("got string, {:?}", s),
+        Value::Vec(v) => v
+            .iter()
+            .for_each(|s| println!("got vec scalar, {:?}", s.as_scalar_ref())),
+    }
+}
+fn print_scalar<T>(t: T)
+where
+    T: AsScalarRef,
+{
+    match t.as_scalar_ref() {
+        Scalar::Addr(addr) => println!("got addr, {:?}", addr),
+        Scalar::Uint32(i) => println!("got int, {}", i),
+        Scalar::String(s) => println!("got string, {:?}", s),
+    }
+}
+fn from_rkyv() {
+    let owned = ScalarOwned::String(String::from("foo"));
+    let mut serializer = WriteSerializer::new(Vec::new());
+    let pos = serializer
+        .serialize_value(&owned)
+        .expect("failed to serialize value");
+    let buf = serializer.into_inner();
+    let archived = unsafe { archived_value::<ScalarOwned>(buf.as_ref(), pos) };
+    print_scalar(&archived);
+    print_scalar(archived);
+    print_scalar(&owned);
+    print_scalar(owned);
+
+    let owned = ValueOwned::Vec(vec![
+        ScalarOwned::String(String::from("foo")),
+        ScalarOwned::String(String::from("var")),
+    ]);
+    let mut serializer = WriteSerializer::new(Vec::new());
+    let pos = serializer
+        .serialize_value(&owned)
+        .expect("failed to serialize value");
+    let buf = serializer.into_inner();
+    let archived = unsafe { archived_value::<ValueOwned>(buf.as_ref(), pos) };
+    print_value(&archived);
+    print_value(archived);
+    print_value(&owned);
+    print_value(owned);
+
+    // tuple for branch
+    let owned = vec![(
+        KeyOwned::Vec(vec![
+            ScalarOwned::String(String::from("foo")),
+            ScalarOwned::String(String::from("var")),
+        ]),
+        Addr([0; 32]),
+    )];
+    let mut serializer = WriteSerializer::new(Vec::new());
+    let pos = serializer
+        .serialize_value(&owned)
+        .expect("failed to serialize value");
+    let buf = serializer.into_inner();
+    let archived = unsafe { archived_value::<Vec<ValueOwned>>(buf.as_ref(), pos) };
+    print_branch_tuple(archived);
+    print_branch_tuple(owned);
+
+    /*
+    let owned = Node::<Vec<(KeyOwned, Addr)>, _>::Leaf(vec![(
+        KeyOwned::String(String::from("foo")),
+        ValueOwned::String(String::from("bar")),
+    )]);
+    let mut serializer = WriteSerializer::new(Vec::new());
+    let pos = serializer
+        .serialize_value(&owned)
+        .expect("failed to serialize value");
+    let buf = serializer.into_inner();
+    let archived = unsafe { archived_value::<NodeOwned>(buf.as_ref(), pos) };
+    print_node(&owned);
+    print_node(owned);
+    //print_node(archived);
+    */
+}
+#[test]
+fn tests() {
+    from_rkyv();
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -51,7 +51,7 @@ pub enum Error {
     #[error("unhandled error: `{message}`")]
     Unhandled { message: String },
     #[error("hash `{addr}` not found")]
-    NotFound { addr: String },
+    NotFound { addr: Addr },
     #[error("io error: {0}")]
     Io(#[from] io::Error),
     #[error("hash `{hash}` io error: {err}")]
@@ -77,4 +77,26 @@ impl Error {
 pub trait AsStorageRef {
     type Storage: Storage;
     fn as_storage_ref(&self) -> &Self::Storage;
+}
+// A NOOP Storage impl.
+#[async_trait::async_trait]
+impl StorageRead for () {
+    async fn read<A, W>(&self, _: A, _: W) -> Result<u64, Error>
+    where
+        A: AsRef<Addr> + 'static + Send,
+        W: AsyncWrite + Unpin + Send,
+    {
+        Ok(0)
+    }
+}
+// A NOOP Storage impl.
+#[async_trait::async_trait]
+impl StorageWrite for () {
+    async fn write<A, R>(&self, _: A, _: R) -> Result<u64, Error>
+    where
+        A: AsRef<Addr> + 'static + Send,
+        R: AsyncRead + Unpin + Send,
+    {
+        Ok(0)
+    }
 }

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -37,7 +37,7 @@ impl StorageRead for Memory {
             })?;
             store
                 .get(&addr)
-                .ok_or_else(|| Error::NotFound { addr: addr.long() })?
+                .ok_or(Error::NotFound { addr })?
                 // cloning for simplicity, since this is a test focused storage impl.
                 .clone()
         };

--- a/src/value.rs
+++ b/src/value.rs
@@ -11,12 +11,12 @@ use {
 
 const PRIMARY_ENCODING: Base = Base::Base58Btc;
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Addr([u8; 32]);
 impl Addr {
     /// The length in bytes of an [`Addr`].
@@ -55,7 +55,6 @@ impl Addr {
     /// let addr = Addr::decode(encoded);
     /// assert_eq!(addr, None);
     /// ```
-    ///
     pub fn decode<S: AsRef<str>>(s: S) -> Option<Self> {
         let (_, bytes) = multibase::decode(s).ok()?;
         let arr: [u8; 32] = bytes.try_into().ok()?;
@@ -73,6 +72,11 @@ impl Addr {
 impl AsRef<Addr> for Addr {
     fn as_ref(&self) -> &Self {
         self
+    }
+}
+impl From<&Addr> for Addr {
+    fn from(t: &Addr) -> Self {
+        t.clone()
     }
 }
 impl TryFrom<Vec<u8>> for Addr {
@@ -98,12 +102,12 @@ impl fmt::Display for Addr {
         write!(f, "{}", self.long())
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Scalar {
     Addr(Addr),
     Uint32(u32),
@@ -136,12 +140,12 @@ impl fmt::Display for Scalar {
 /// Key exists as a very thin layer over a [`Value`] for ease of use and reading.
 ///
 /// Ultimately there is no difference between a Key and a Value.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Key(pub Value);
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -164,12 +168,12 @@ where
         Self(t.into())
     }
 }
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshSerialize, borsh::BorshDeserialize)
 )]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Value {
     Addr(Addr),
     Uint32(u32),
@@ -199,15 +203,15 @@ impl Value {
                 // TODO: is there a way we can encode this without allocating? Perhaps into
                 // a different encoding?
                 f.write_str(v.long().as_str())?;
-            }
+            },
             Self::Uint32(v) => {
                 f.write_str("Uint32(")?;
                 write!(f, "{}", v)?;
-            }
+            },
             Self::String(v) => {
                 f.write_str("String(")?;
                 f.write_str(v.as_str())?;
-            }
+            },
             Self::Vec(v) => {
                 f.write_str("Vec([\n")?;
                 let iter = v.iter();
@@ -217,7 +221,7 @@ impl Value {
                     f.write_str(",\n")?;
                 }
                 f.write_str("]")?;
-            }
+            },
         }
         Ok(())
     }


### PR DESCRIPTION
During experimentation with `rkyv` it became apparent that
the caching API would benefit from being able to cache the
deserialized result, in additon to avoiding allocations
during deserialization and borrow from the underlying data.

While the `rkyv` work has not yet proved successful, the
API has changed enough that mainlining this seems productive.